### PR TITLE
Add attribute support to Text tags

### DIFF
--- a/src/main/java/org/guideme/guideme/MainLogic.java
+++ b/src/main/java/org/guideme/guideme/MainLogic.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.guideme.guideme.model.Audio;
 import org.guideme.guideme.model.Button;
 import org.guideme.guideme.model.Delay;
+import org.guideme.guideme.model.Text;
 import org.guideme.guideme.model.Timer;
 import org.guideme.guideme.model.Guide;
 import org.guideme.guideme.model.Image;
@@ -328,7 +329,7 @@ public class MainLogic {
 		Page objCurrPage = guide.getChapters().get(chapterName).getPages().get("GuideMe404Error");
 		String strText = "<div><p><h1>Oops it looks like page " + strPageId + " does not exist</h1></p>";
 		strText = strText + "<p>Please contact the Author to let them know the issue</p></div>"; 
-		objCurrPage.setText(strText);
+		objCurrPage.addText(new Text(strText));
 		return objCurrPage;
 	}
 	
@@ -613,7 +614,14 @@ public class MainLogic {
 		//Replace any string pref in the HTML with the user preference
 		//they are encoded #prefName# 
 		try {
-			String displayText = objCurrPage.getLeftText();
+			StringBuilder displayTextBuilder = new StringBuilder();
+			for (int i = 0; i < objCurrPage.getLeftTextCount(); i++) {
+				if (objCurrPage.getLeftText(i).canShow(guide.getFlags())) {
+					displayTextBuilder.append(objCurrPage.getLeftText(i).getText());
+				}
+			}
+			String displayText = displayTextBuilder.toString();
+
 			// Media Directory
 			try {
 				String mediaPath;
@@ -690,7 +698,13 @@ public class MainLogic {
 		try {
 			String displayText = "";
 			if (overRide.getHtml().equals("") && overRide.getRightHtml().equals("")) {
-				displayText = objCurrPage.getText();
+				StringBuilder displayTextBuilder = new StringBuilder();
+				for (int i = 0; i < objCurrPage.getTextCount(); i++) {
+					if (objCurrPage.getText(i).canShow(guide.getFlags())) {
+						displayTextBuilder.append(objCurrPage.getText(i).getText());
+					}
+				}
+				displayText = displayTextBuilder.toString();
 			} else {
 				if (!overRide.getHtml().equals("")) {
 					displayText = overRide.getHtml();

--- a/src/main/java/org/guideme/guideme/model/Page.java
+++ b/src/main/java/org/guideme/guideme/model/Page.java
@@ -6,9 +6,9 @@ import java.util.ArrayList;
 import org.guideme.guideme.settings.ComonFunctions;
 
 public class Page {
-	private String text = ""; //HTML to display
-	private String leftText = ""; //HTML to display in the left pane instead of an image
 	private String id; //Page Name
+	private ArrayList<Text> text = new ArrayList<Text>(); //HTML to display
+	private ArrayList<Text> leftText = new ArrayList<Text>(); //HTML to display in the left pane instead of an image
 	private ArrayList<Button> button = new ArrayList<Button>();
 	private ArrayList<WebcamButton> webcamButton = new ArrayList<WebcamButton>();
 	private ArrayList<Delay> delay = new ArrayList<Delay>(); 
@@ -30,12 +30,16 @@ public class Page {
 	private ComonFunctions comonFunctions = ComonFunctions.getComonFunctions();
 	
 	
-	public String getLeftText() {
-		return leftText;
+	public Text getLeftText(int txtIndex) {
+		return leftText.get(txtIndex);
 	}
 
-	public void setLeftText(String leftText) {
-		this.leftText = leftText;
+	public void addLeftText(Text leftText) {
+		this.leftText.add(leftText);
+	}
+
+	public int getLeftTextCount() {
+		return this.leftText.size();
 	}
 
 	public Page(String id) {
@@ -216,12 +220,16 @@ public class Page {
 		return audio.size();
 	}
 
-	public String getText() {
-		return text;
+	public Text getText(int txtIndex) {
+		return text.get(txtIndex);
 	}
 
-	public void setText(String text) {
-		this.text = text;
+	public void addText(Text text) {
+		this.text.add(text);
+	}
+
+	public int getTextCount() {
+		return this.text.size();
 	}
 
 	public String getjScript() {
@@ -283,8 +291,4 @@ public class Page {
 	public int getAudio2Count() {
 		return audio2.size();
 	}
-
-	
-	
-	
 }

--- a/src/main/java/org/guideme/guideme/model/Text.java
+++ b/src/main/java/org/guideme/guideme/model/Text.java
@@ -1,0 +1,60 @@
+package org.guideme.guideme.model;
+
+import org.guideme.guideme.settings.ComonFunctions;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+
+public class Text
+{
+	private final String ifSet;
+	private final String ifNotSet;
+	private final LocalTime ifBefore; //Time of day must be before this time
+	private final LocalTime ifAfter; //Time of day must be after this time
+	private final String text;
+	private final ComonFunctions comonFunctions = ComonFunctions.getComonFunctions();
+
+	public Text(String text)
+	{
+		this(text, "", "", "", "");
+	}
+
+	public Text(String text, String ifSet, String ifNotSet)
+	{
+		this(text, ifSet, ifNotSet, "", "");
+	}
+
+	public Text(String text, String ifSet, String ifNotSet, String ifBefore, String ifAfter)
+	{
+		this.text = text;
+		this.ifNotSet = ifNotSet;
+		this.ifSet = ifSet;
+		this.ifBefore = ifBefore == null || ifBefore.isEmpty() ? null : LocalTime.parse(ifBefore);
+		this.ifAfter = ifAfter == null || ifAfter.isEmpty() ? null : LocalTime.parse(ifAfter);
+	}
+
+	public boolean canShow(ArrayList<String> setList)
+	{
+		return comonFunctions.canShow(setList, ifSet, ifNotSet) && comonFunctions.canShowTime(ifBefore, ifAfter);
+	}
+
+	public String getText() {
+		return this.text;
+	}
+
+	public String getIfSet() {
+		return ifSet;
+	}
+
+	public String getIfNotSet() {
+		return ifNotSet;
+	}
+
+	public LocalTime getIfBefore() {
+		return ifBefore;
+	}
+
+	public LocalTime getIfAfter() {
+		return ifAfter;
+	}
+}

--- a/src/main/java/org/guideme/guideme/readers/MilovanaHtmlReader.java
+++ b/src/main/java/org/guideme/guideme/readers/MilovanaHtmlReader.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.guideme.guideme.model.Chapter;
 import org.guideme.guideme.model.Guide;
 import org.guideme.guideme.model.Page;
+import org.guideme.guideme.model.Text;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -69,7 +70,7 @@ public class MilovanaHtmlReader {
 		if (elm.size() > 0) {
 			String text = elm.first().text().replace('\r', ' ').replace('\n', ' ');
 			text = CharSetUtils.squeeze(text, " ");
-			page.setText(text);
+			page.addText(new Text(text));
 		}
 			
 		chapter.getPages().put(page.getId(), page);

--- a/src/main/java/org/guideme/guideme/readers/XmlGuideReader.java
+++ b/src/main/java/org/guideme/guideme/readers/XmlGuideReader.java
@@ -25,6 +25,7 @@ import org.guideme.guideme.model.Image;
 import org.guideme.guideme.model.LoadGuide;
 import org.guideme.guideme.model.Metronome;
 import org.guideme.guideme.model.Page;
+import org.guideme.guideme.model.Text;
 import org.guideme.guideme.model.Timer;
 import org.guideme.guideme.model.Video;
 import org.guideme.guideme.model.Webcam;
@@ -781,9 +782,18 @@ public class XmlGuideReader {
 						break;
 					case Text:
 						try {
+							ifSet = reader.getAttributeValue(null, "if-set");
+							if (ifSet == null) ifSet = "";
+							ifNotSet = reader.getAttributeValue(null, "if-not-set");
+							if (ifNotSet == null) ifNotSet = "";
+							ifBefore = reader.getAttributeValue(null, "if-before");
+							if (ifBefore == null) ifBefore = "";
+							ifAfter = reader.getAttributeValue(null, "if-after");
+							if (ifAfter == null) ifAfter = "";
+
 							if (reader.getName().getLocalPart().equals("Text")) {
 								String text = processText(reader, "Text");
-								page.setText(text);
+								page.addText(new Text(text, ifSet, ifNotSet, ifBefore, ifAfter));
 								logger.trace("loadXML " + PresName + " Text " + text);
 							}
 						} catch (Exception e1) {
@@ -792,9 +802,18 @@ public class XmlGuideReader {
 						break;
 					case LeftText:
 						try {
+							ifSet = reader.getAttributeValue(null, "if-set");
+							if (ifSet == null) ifSet = "";
+							ifNotSet = reader.getAttributeValue(null, "if-not-set");
+							if (ifNotSet == null) ifNotSet = "";
+							ifBefore = reader.getAttributeValue(null, "if-before");
+							if (ifBefore == null) ifBefore = "";
+							ifAfter = reader.getAttributeValue(null, "if-after");
+							if (ifAfter == null) ifAfter = "";
+
 							if (reader.getName().getLocalPart().equals("LeftText")) {
 								String text = processText(reader, "LeftText");
-								page.setLeftText(text);
+								page.addText(new Text(text, ifSet, ifNotSet, ifBefore, ifAfter));
 								logger.trace("loadXML " + PresName + " Left Text " + text);
 							}
 						} catch (Exception e1) {

--- a/src/main/java/org/guideme/guideme/ui/DebugShell.java
+++ b/src/main/java/org/guideme/guideme/ui/DebugShell.java
@@ -419,7 +419,13 @@ public class DebugShell {
 				refreshVars = true;
 			}
 			this.dispPage = guide.getChapters().get("default").getPages().get(page);
-			txtText.setText(dispPage.getText());
+			StringBuilder txtBuilder = new StringBuilder();
+			for (int i = 0; i < dispPage.getTextCount(); i++) {
+				if (dispPage.getText(i).canShow(guide.getFlags())) {
+					txtBuilder.append(dispPage.getText(i).getText());
+				}
+			}
+			txtText.setText(txtBuilder.toString());
 			removePageTables();
 			Control prevWidget;
 			prevWidget = tableComp;


### PR DESCRIPTION
Adds support for if-set, if-not-set, if-before, and if-after attributes to Text tags. Please note, attributes are only supported on the root `<Text>` tag, and not on sub-nodes such as `<P>` tags etc.

Perhaps somewhat obviously, this also means `<Text>` nodes can appear more than once in a `<Page>` now. Text nodes are concatenated in the order they appear, taking into consideration the conditional attributes. An abbreviated constructor needing only the text string was created on the `Text` model to aid in backwards compatibility and creating special pages (like the 404) on the fly.

You can use [This Test Script](https://github.com/guide-me/GuideMe/files/5213473/text_test.xml.txt) (txt extension added to make GitHub happy) to test these new features.



Resolves #9 